### PR TITLE
Replace the command mkisofs with genisoimage

### DIFF
--- a/seedbank/iso.py
+++ b/seedbank/iso.py
@@ -130,7 +130,7 @@ class Build:
         utils.run('cd "%s" && %s $(find . \! -name "md5sum.txt" \! -path '
             '"./%s*" -follow -type f) > md5sum.txt' % (self.work_iso, md5,
             isolinux))
-        utils.run('cd "%s" && mkisofs -quiet -o "%s" -r -J -no-emul-boot '
+        utils.run('cd "%s" && genisoimage -quiet -o "%s" -r -J -no-emul-boot '
             '-boot-load-size 4 -boot-info-table -b %sisolinux.bin -c '
             '%sboot.cat iso' % (self.work_path, self.iso_dst, isolinux,
             isolinux))


### PR DESCRIPTION
The command `mkisofs` is only available on Ubuntu but not on Debian. The command `mkisofs` is symlink for the command `genisoimage`.